### PR TITLE
Adicionado tratamento para comentários

### DIFF
--- a/src/App.java
+++ b/src/App.java
@@ -36,12 +36,15 @@ public class App {
                         break;
                     end
 
-                    if ((x_1 + x_2) < 20) do
+                    if ((x_1 + x_2) < 20) do    // Teste linha comentário
                         x_1 := x_1 + 1;
                     else
                         print(0);
                     end
 
+                    /* Comentário
+                    de bloco */
+                    
                     x_2 := x_2 * 2 / 3000;
                     x_3 := function#soma(1, 2);
                     procedure#menos(x_1, x_2);

--- a/src/lexer/Lexer.java
+++ b/src/lexer/Lexer.java
@@ -38,6 +38,12 @@ public class Lexer {
 
             if (Character.isWhitespace(charAtual)) {
                 skipWhitespace();
+            // Tratamento de comentários de linha: "//"
+            } else if (charAtual == '/' && (posicao + 1 < codigo.length() && codigo.charAt(posicao + 1) == '/')) {
+                skipComentarioLinha();
+            // Tratamento de comentários de bloco: "/* ... */"
+            } else if (charAtual == '/' && (posicao + 1 < codigo.length() && codigo.charAt(posicao + 1) == '*')) {
+                skipComentarioBloco();
             } else if (isMatch("[a-zA-Z_]", charAtual)) {
                 // System.out.println("Letra charAtual: " + charAtual);
                 tokens.add(lexemaIdentificador());
@@ -207,4 +213,66 @@ public class Lexer {
         Matcher matcher = pattern.matcher(String.valueOf(charAtual));
         return matcher.matches();
     }
+
+    private void ignorarComentarios() {
+        if (posicao < codigo.length() - 1) {
+            // Detecta comentários de linha: "//"
+            if (codigo.charAt(posicao) == '/' && codigo.charAt(posicao + 1) == '/') {
+                posicao += 2;
+                coluna += 2;
+                while (posicao < codigo.length() && codigo.charAt(posicao) != '\n') {
+                    posicao++;
+                    coluna++;
+                }
+            }
+            // Detecta comentários de bloco: "/* ... */"
+            else if (codigo.charAt(posicao) == '/' && codigo.charAt(posicao + 1) == '*') {
+                posicao += 2;
+                coluna += 2;
+                while (posicao < codigo.length() - 1) {
+                    if (codigo.charAt(posicao) == '*' && codigo.charAt(posicao + 1) == '/') {
+                        posicao += 2;
+                        coluna += 2;
+                        break;
+                    }
+                    if (codigo.charAt(posicao) == '\n') {
+                        linha++;
+                        coluna = 1;
+                    } else {
+                        coluna++;
+                    }
+                    posicao++;
+                }
+            }
+        }
+    }
+    
+    private void skipComentarioLinha() {
+        posicao += 2;
+        coluna += 2;
+        while (posicao < codigo.length() && codigo.charAt(posicao) != '\n') {
+            posicao++;
+            coluna++;
+        }
+    }
+    
+    private void skipComentarioBloco() {
+        posicao += 2;
+        coluna += 2;
+        while (posicao < codigo.length() - 1) {
+            if (codigo.charAt(posicao) == '*' && codigo.charAt(posicao + 1) == '/') {
+                posicao += 2;
+                coluna += 2;
+                break;
+            }
+            if (codigo.charAt(posicao) == '\n') {
+                linha++;
+                coluna = 1;
+            } else {
+                coluna++;
+            }
+            posicao++;
+        }
+    }
+    
 }


### PR DESCRIPTION
Uma vez que os comentários servem apenas como documentação do código fonte, ao realizar a compilação deste código faz-se necessário eliminar todo o conteúdo entre seus delimitadores.

delimitadores : //* *//
